### PR TITLE
後処理がされておらず後続のDBテストが失敗するため修正

### DIFF
--- a/src/test/java/nablarch/test/junit5/extension/db/DbAccessTestExtensionTest.java
+++ b/src/test/java/nablarch/test/junit5/extension/db/DbAccessTestExtensionTest.java
@@ -20,32 +20,23 @@ class DbAccessTestExtensionTest {
     final DbAccessTestExtension sut = new DbAccessTestExtension();
 
     @Test
-    void beforeEachを実行すると_TestRuleが再現され_DbAccessTestSupportとTestEventDispatcherで定義されたテスト開始前の処理が実行されることをテスト() throws Exception {
+    void DbAccessTestSupportと同等の処理が実行されることをテスト() throws Exception {
         sut.postProcessTestInstance(this, null);
 
         new Expectations(support) {{
             support.beginTransactions(); times = 1;
             support.dispatchEventOfBeforeTestMethod(); times = 1;
+            support.endTransactions(); times = 1;
+            support.dispatchEventOfAfterTestMethod(); times = 1;
         }};
 
         ExtensionContext context = new MockExtensionContext(DbAccessTestExtensionTest.class,
                 DbAccessTestExtensionTest.class.getDeclaredMethod("testForMock"));
 
         sut.beforeEach(context);
+        sut.afterEach(context);
 
         assertThat(support.testName.getMethodName(), is("testForMock"));
-    }
-
-    @Test
-    void afterEachを実行すると_DbAccessTestSupportとTestEventDispatcherで定義されたテスト終了後の処理が実行されることをテスト() throws Exception {
-        sut.postProcessTestInstance(this, null);
-
-        new Expectations(support) {{
-            support.endTransactions(); times = 1;
-            support.dispatchEventOfAfterTestMethod(); times = 1;
-        }};
-
-        sut.afterEach(null);
     }
 
     /**


### PR DESCRIPTION
## 事象

CIのDBバリエーションテストにて、`DbAccessTestExtensionIntegrationTest`でトランザクション名が重複しているというエラーが発生している。
`transaction`はデフォルトのトランザクション名のためそれぞれのテストで同じ名前が使われるが、`afterEach`の後処理で該当コネクションを削除するため次のテスト実施時には重複しない想定になっている。

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.121 s <<< FAILURE! - in nablarch.test.junit5.extension.db.DbAccessTestExtensionIntegrationTest
[ERROR] DbAccessTestExtensionが適用できていることをテスト  Time elapsed: 0.093 s  <<< ERROR!
java.lang.IllegalStateException: The specified database connection name is already used. connection name=[transaction]
（省略）
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   DbAccessTestExtensionIntegrationTest.DbAccessTestExtensionが適用できていることをテスト » IllegalState
[INFO] 
[ERROR] Tests run: 32, Failures: 0, Errors: 1, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:21 min
[INFO] Finished at: 2023-06-29T17:29:24+09:00
[INFO] ------------------------------------------------------------------------
```

## 原因

エラー原因は、失敗している`DbAccessTestExtensionIntegrationTest`ではなく`DbAccessTestExtensionTest`だった。
`DbAccessTestExtensionTest`では`beforeaEach`の実装をテストをしているが、その後に`afterEach`を呼んでいないため、`beforeEach`で作成したコネクションがスレッドローカルに残ったままになっていた。
（`afterEach`のテストは別テストケースでしているが、そこでは`beforeEach`を呼んでいないためコネクションが作成されず、削除はされないままになっている）

そのため、`DbAccessTestExtensionTest`の後に`DbAccessTestExtensionIntegrationTest`が実行されると、今回のエラーが発生してしまう。
テスト実行順序は保証されておらず、ビルド時の環境等で変わってしまうため、今回のようにv6でだけ且つ特定のDBテスト用環境でだけ発生していたと考えられる。

## 対応

v6だけでなくv5でも起きうるので、v5も含めて、`beforeEach`のテストでは`afterEach`も合わせてテストするように変更した。